### PR TITLE
Pin gym for rllib

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-  gym
+  gym==0.21.0
   tensorflow
   networkx
   ray[tune,rllib]


### PR DESCRIPTION
Not sure why docker builds aren't picking up rllib's max gym version, but tests are failing on with gym=0.23.1
**Edit**, we might not need this here actually, could be our previous dockerfile was wrong