### PR TITLE
only assert tfv=2 if we have tensorflow installed

### DIFF
--- a/graphenv/__init__.py
+++ b/graphenv/__init__.py
@@ -7,7 +7,9 @@ except ImportError:
     __version_tuple__ = (0, 0, "unknown version")
 
 tf1, tf, tfv = try_import_tf()
-assert tfv == 2
+
+if tf is not None:
+    assert tfv == 2, "GraphEnv only supports tensorflow 2.x"
 if not tf1.executing_eagerly():
     tf1.enable_eager_execution()
 


### PR DESCRIPTION
resolves #36

This was introduced by #34 where we made the NN packages optional, but didn't change the import in `__init__.py` to reflect that change.

Here, we'll only error out (with a description as to why) if the user is importing tf = 1.x